### PR TITLE
Feature fe demo user

### DIFF
--- a/client/src/components/DemoButton/DemoButton.tsx
+++ b/client/src/components/DemoButton/DemoButton.tsx
@@ -1,0 +1,44 @@
+import Button from '@mui/material/Button';
+import useStyles from './useStyles';
+import { useAuth } from '../../context/useAuthContext';
+import { useSnackBar } from '../../context/useSnackbarContext';
+import demoLogin from '../../helpers/APICalls/demoLogin';
+
+interface Props {
+  text: string;
+  path: string;
+}
+
+function DemoLogin({ text, path }: Props): JSX.Element {
+  const { updateLoginContext } = useAuth();
+  const { updateSnackBarMessage } = useSnackBar();
+  const classes = useStyles();
+
+  const handleSubmit = async () => {
+    const data = await demoLogin(path);
+    if (data.error) {
+      updateSnackBarMessage(data.error.message);
+    } else if (data.success) {
+      updateSnackBarMessage(data.success);
+      updateLoginContext(data.success);
+    } else {
+      updateSnackBarMessage('unexpected error occurred!');
+    }
+  };
+  return (
+    <form onSubmit={handleSubmit}>
+      <Button
+        className={classes.demoButton}
+        type="submit"
+        size="large"
+        variant="contained"
+        color="primary"
+        disableElevation
+      >
+        {text}
+      </Button>
+    </form>
+  );
+}
+
+export default DemoLogin;

--- a/client/src/components/DemoButton/useStyles.ts
+++ b/client/src/components/DemoButton/useStyles.ts
@@ -1,5 +1,5 @@
-import { Theme } from '@mui/material/styles';
 import { makeStyles } from '@mui/styles';
+import { Theme } from '@mui/material/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
   demoButton: {

--- a/client/src/helpers/APICalls/demoLogin.ts
+++ b/client/src/helpers/APICalls/demoLogin.ts
@@ -1,0 +1,17 @@
+import { FetchOptions } from '../../interface/FetchOptions';
+
+const demoLogin = async (path: string) => {
+  const fetchOptions: FetchOptions = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+  };
+  console.log(path);
+  return await fetch(`/auth/demo/${path}`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export default demoLogin;

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -6,58 +6,11 @@ import { useSnackBar } from '../../context/useSnackbarContext';
 import PageContainer from '../../components/PageContainer/PageContainer';
 import AuthPageWrapper from '../../components/AuthPageWrapper/AuthPageWrapper';
 import AuthPageFooter from '../../components/AuthPageFooter/AuthPageFooter';
-import Button from '@mui/material/Button';
-import { FetchOptions } from '../../interface/FetchOptions';
-import useStyles from './useStyles';
-
-function DemoLogin(): JSX.Element {
-  const { updateLoginContext } = useAuth();
-  const { updateSnackBarMessage } = useSnackBar();
-  const classes = useStyles();
-
-  const handleSubmit = async () => {
-    const fetchOptions: FetchOptions = {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-    };
-    return await fetch(`/auth/demo/login`, fetchOptions)
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.error) {
-          updateSnackBarMessage(data.error.message);
-        } else if (data.success) {
-          updateSnackBarMessage(data.success);
-          updateLoginContext(data.success);
-        } else {
-          console.log({ data });
-          updateSnackBarMessage('unexpected error occurred!');
-        }
-      })
-      .catch(() => ({
-        error: { message: 'Unable to connect to server. Please try again' },
-      }));
-  };
-  return (
-    <form onSubmit={handleSubmit}>
-      <Button
-        className={classes.demoButton}
-        type="submit"
-        size="large"
-        variant="contained"
-        color="primary"
-        disableElevation
-      >
-        Demo Login
-      </Button>
-    </form>
-  );
-}
+import DemoButton from '../../components/DemoButton/DemoButton';
 
 export default function Login(): JSX.Element {
   const { updateLoginContext } = useAuth();
   const { updateSnackBarMessage } = useSnackBar();
-
   const handleSubmit = (
     { email, password }: { email: string; password: string },
     { setSubmitting }: FormikHelpers<{ email: string; password: string }>,
@@ -82,7 +35,7 @@ export default function Login(): JSX.Element {
     <PageContainer>
       <AuthPageWrapper header="Log in">
         <LoginForm handleSubmit={handleSubmit} />
-        <DemoLogin />
+        <DemoButton text="Demo Login" path="login" />
         <AuthPageFooter text="Not a member?" anchorText="Sign up" anchorTo="/signup" />
       </AuthPageWrapper>
     </PageContainer>

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -6,6 +6,53 @@ import { useSnackBar } from '../../context/useSnackbarContext';
 import PageContainer from '../../components/PageContainer/PageContainer';
 import AuthPageWrapper from '../../components/AuthPageWrapper/AuthPageWrapper';
 import AuthPageFooter from '../../components/AuthPageFooter/AuthPageFooter';
+import Button from '@mui/material/Button';
+import { FetchOptions } from '../../interface/FetchOptions';
+import useStyles from './useStyles';
+
+function DemoLogin(): JSX.Element {
+  const { updateLoginContext } = useAuth();
+  const { updateSnackBarMessage } = useSnackBar();
+  const classes = useStyles();
+
+  const handleSubmit = async () => {
+    const fetchOptions: FetchOptions = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+    };
+    return await fetch(`/auth/demo/login`, fetchOptions)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.error) {
+          updateSnackBarMessage(data.error.message);
+        } else if (data.success) {
+          updateSnackBarMessage(data.success);
+          updateLoginContext(data.success);
+        } else {
+          console.log({ data });
+          updateSnackBarMessage('unexpected error occurred!');
+        }
+      })
+      .catch(() => ({
+        error: { message: 'Unable to connect to server. Please try again' },
+      }));
+  };
+  return (
+    <form onSubmit={handleSubmit}>
+      <Button
+        className={classes.demoButton}
+        type="submit"
+        size="large"
+        variant="contained"
+        color="primary"
+        disableElevation
+      >
+        Demo Login
+      </Button>
+    </form>
+  );
+}
 
 export default function Login(): JSX.Element {
   const { updateLoginContext } = useAuth();
@@ -35,6 +82,7 @@ export default function Login(): JSX.Element {
     <PageContainer>
       <AuthPageWrapper header="Log in">
         <LoginForm handleSubmit={handleSubmit} />
+        <DemoLogin />
         <AuthPageFooter text="Not a member?" anchorText="Sign up" anchorTo="/signup" />
       </AuthPageWrapper>
     </PageContainer>

--- a/client/src/pages/Login/useStyles.ts
+++ b/client/src/pages/Login/useStyles.ts
@@ -18,19 +18,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: '#000000',
     fontWeight: 700,
   },
-  demoButton: {
-    margin: theme.spacing(3, 2, 2),
-    padding: 10,
-    width: 160,
-    height: 56,
-    borderRadius: theme.shape.borderRadius,
-    fontSize: 16,
-    backgroundColor: theme.palette.primary.main,
-    fontWeight: 'bold',
-    textTransform: 'uppercase',
-    left: 95,
-    top: 15,
-  },
 }));
 
 export default useStyles;

--- a/client/src/pages/Login/useStyles.ts
+++ b/client/src/pages/Login/useStyles.ts
@@ -28,7 +28,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundColor: theme.palette.primary.main,
     fontWeight: 'bold',
     textTransform: 'uppercase',
-    left: 75,
+    left: 95,
+    top: 15,
   },
 }));
 

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -6,54 +6,6 @@ import { useSnackBar } from '../../context/useSnackbarContext';
 import AuthPageWrapper from '../../components/AuthPageWrapper/AuthPageWrapper';
 import PageContainer from '../../components/PageContainer/PageContainer';
 import AuthPageFooter from '../../components/AuthPageFooter/AuthPageFooter';
-import Button from '@mui/material/Button';
-import { FetchOptions } from '../../interface/FetchOptions';
-import useStyles from './useStyles';
-import Box from '@mui/material/Box';
-
-function DemoSignUp(): JSX.Element {
-  const { updateLoginContext } = useAuth();
-  const { updateSnackBarMessage } = useSnackBar();
-  const classes = useStyles();
-
-  const handleSubmit = async () => {
-    const fetchOptions: FetchOptions = {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-    };
-    return await fetch(`/auth/demo/signup`, fetchOptions)
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.error) {
-          updateSnackBarMessage(data.error.message);
-        } else if (data.success) {
-          updateSnackBarMessage(data.success);
-          updateLoginContext(data.success);
-        } else {
-          console.log({ data });
-          updateSnackBarMessage('unexpected error occurred!');
-        }
-      })
-      .catch(() => ({
-        error: { message: 'Unable to connect to server. Please try again' },
-      }));
-  };
-  return (
-    <form onSubmit={handleSubmit}>
-      <Button
-        className={classes.demoButton}
-        type="submit"
-        size="large"
-        variant="contained"
-        color="primary"
-        disableElevation
-      >
-        Demo SignUp
-      </Button>
-    </form>
-  );
-}
 
 export default function Register(): JSX.Element {
   const { updateLoginContext } = useAuth();
@@ -84,7 +36,6 @@ export default function Register(): JSX.Element {
     <PageContainer>
       <AuthPageWrapper header="Sign up">
         <SignUpForm handleSubmit={handleSubmit} />
-        <DemoSignUp />
         <AuthPageFooter text="Already a member?" anchorText="Login" anchorTo="/login" />
       </AuthPageWrapper>
     </PageContainer>

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -84,9 +84,7 @@ export default function Register(): JSX.Element {
     <PageContainer>
       <AuthPageWrapper header="Sign up">
         <SignUpForm handleSubmit={handleSubmit} />
-        <Box>
-          <DemoSignUp />
-        </Box>
+        <DemoSignUp />
         <AuthPageFooter text="Already a member?" anchorText="Login" anchorTo="/login" />
       </AuthPageWrapper>
     </PageContainer>

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -6,6 +6,7 @@ import { useSnackBar } from '../../context/useSnackbarContext';
 import AuthPageWrapper from '../../components/AuthPageWrapper/AuthPageWrapper';
 import PageContainer from '../../components/PageContainer/PageContainer';
 import AuthPageFooter from '../../components/AuthPageFooter/AuthPageFooter';
+import DemoButton from '../../components/DemoButton/DemoButton';
 
 export default function Register(): JSX.Element {
   const { updateLoginContext } = useAuth();
@@ -36,6 +37,7 @@ export default function Register(): JSX.Element {
     <PageContainer>
       <AuthPageWrapper header="Sign up">
         <SignUpForm handleSubmit={handleSubmit} />
+        <DemoButton text="Demo Sign up" path="signup" />
         <AuthPageFooter text="Already a member?" anchorText="Login" anchorTo="/login" />
       </AuthPageWrapper>
     </PageContainer>

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -6,6 +6,54 @@ import { useSnackBar } from '../../context/useSnackbarContext';
 import AuthPageWrapper from '../../components/AuthPageWrapper/AuthPageWrapper';
 import PageContainer from '../../components/PageContainer/PageContainer';
 import AuthPageFooter from '../../components/AuthPageFooter/AuthPageFooter';
+import Button from '@mui/material/Button';
+import { FetchOptions } from '../../interface/FetchOptions';
+import useStyles from './useStyles';
+import Box from '@mui/material/Box';
+
+function DemoSignUp(): JSX.Element {
+  const { updateLoginContext } = useAuth();
+  const { updateSnackBarMessage } = useSnackBar();
+  const classes = useStyles();
+
+  const handleSubmit = async () => {
+    const fetchOptions: FetchOptions = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+    };
+    return await fetch(`/auth/demo/signup`, fetchOptions)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.error) {
+          updateSnackBarMessage(data.error.message);
+        } else if (data.success) {
+          updateSnackBarMessage(data.success);
+          updateLoginContext(data.success);
+        } else {
+          console.log({ data });
+          updateSnackBarMessage('unexpected error occurred!');
+        }
+      })
+      .catch(() => ({
+        error: { message: 'Unable to connect to server. Please try again' },
+      }));
+  };
+  return (
+    <form onSubmit={handleSubmit}>
+      <Button
+        className={classes.demoButton}
+        type="submit"
+        size="large"
+        variant="contained"
+        color="primary"
+        disableElevation
+      >
+        Demo SignUp
+      </Button>
+    </form>
+  );
+}
 
 export default function Register(): JSX.Element {
   const { updateLoginContext } = useAuth();
@@ -36,6 +84,9 @@ export default function Register(): JSX.Element {
     <PageContainer>
       <AuthPageWrapper header="Sign up">
         <SignUpForm handleSubmit={handleSubmit} />
+        <Box>
+          <DemoSignUp />
+        </Box>
         <AuthPageFooter text="Already a member?" anchorText="Login" anchorTo="/login" />
       </AuthPageWrapper>
     </PageContainer>

--- a/client/src/pages/SignUp/useStyles.ts
+++ b/client/src/pages/SignUp/useStyles.ts
@@ -1,23 +1,7 @@
-import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    minHeight: '100vh',
-    '& .MuiInput-underline:before': {
-      borderBottom: '1.2px solid rgba(0, 0, 0, 0.2)',
-    },
-  },
-  authWrapper: {
-    minHeight: '100vh',
-    paddingTop: 23,
-  },
-  welcome: {
-    fontSize: 26,
-    paddingBottom: 20,
-    color: '#000000',
-    fontWeight: 700,
-  },
   demoButton: {
     margin: theme.spacing(3, 2, 2),
     padding: 10,

--- a/client/src/pages/SignUp/useStyles.ts
+++ b/client/src/pages/SignUp/useStyles.ts
@@ -12,7 +12,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundColor: theme.palette.primary.main,
     fontWeight: 'bold',
     textTransform: 'uppercase',
-    left: 75,
+    left: 95,
+    top: 15,
   },
 }));
 


### PR DESCRIPTION
### What this PR does (required):
- a demo Login and Sign Up button provided which calls the backend `/auth/demo/login` and `/auth/demo/signup` to load the user and bypass providing data to the form to achieve same functionality

### Screenshots / Videos (front-end only):
![1](https://user-images.githubusercontent.com/56316259/149984127-a56065b4-278c-4f11-bd4a-8507aa41d1e4.png)
![2](https://user-images.githubusercontent.com/56316259/149984153-f39d0e8d-791b-4472-ab7f-18775d6aeb01.png)

### Any information needed to test this feature (required):
- To see exact login functionality, this feature needs backend to provide  `/auth/demo/login` and `/auth/demo/signup`  endpoints where a logged user object is returned upon post request with application/json as content-type

