### PR TITLE
BE-AvailabilitySchema

### DIFF
--- a/server/models/Availability.js
+++ b/server/models/Availability.js
@@ -1,0 +1,45 @@
+const mongoose = require('mongoose');
+
+const DaySchema = new mongoose.Schema({
+    name: {
+        type: String,
+        enum: ["Monday", "Tuesday", "Thursday", "Friday", "Saturday", "Sunday"],
+        required: true,
+    },
+    startTime: {
+        type: String,
+    },
+    endTime: {
+        type: String,
+    },
+});
+
+const ScheduleSchema = new mongoose.Schema({
+    name: {
+        type: String,
+        default: "Default Schedule"
+    },
+    days: {
+        type: [DaySchema],
+    },
+});
+
+const AvailabilitySchema = new mongoose.Schema({
+    sitterId: {
+        type: mongoose.Types.ObjectId,
+        ref: 'PetSitter',
+    },
+    schedule: {
+        type: [ScheduleSchema],
+        required: true,
+    },
+    activeSchedule: {
+        type: mongoose.Types.ObjectId,
+    },
+});
+
+module.exports = {
+    Availability: new mongoose.model('Availability', AvailabilitySchema),
+    Schedule: new mongoose.model('Schedule', ScheduleSchema),
+    Day: new mongoose.model('Day', DaySchema),
+}

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
     "test": "test"
   },
   "scripts": {
+    "testAvailabilitySchema": "mocha ./test/availability.spec.js -r dotenv/config",
     "testPayment": "mocha ./test/payment.spec.js",
     "testRequests": "mocha ./test/models.spec.js -r dotenv/config",
     "dev": "nodemon ./bin/www"

--- a/server/test/availability.spec.js
+++ b/server/test/availability.spec.js
@@ -1,0 +1,56 @@
+const chai = require('chai');
+
+const connectDB = require('../db');
+const mongoose = require('mongoose');
+const { Availability, Schedule, Day} = require('../models/Availability');
+
+const expect = chai.expect;
+
+describe("Availability Schema", function() {
+    let availability;
+    let schedule;
+    let dayOne, dayTwo;
+
+    before(function() {
+        connectDB();
+    })
+    it("should create a day document", function() {
+        dayOne = new Day({
+            name: "Monday",
+            startTime: "10:00",
+            endTime: "18:00",
+        });
+        expect(dayOne).to.be.an.instanceOf(Day);
+    })
+    it("should create a schedule document", function () {
+        schedule = new Schedule({
+            name: "Work Schedule A",
+            days: [dayOne]
+        })
+        expect(schedule).to.be.an.instanceOf(Schedule);
+    })
+    it("should push a day into a schedule", function() {
+        dayTwo = new Day({
+            name: "Tuesday",
+            startTime: "8:00",
+            endTime: "21:00",
+        });
+        schedule.days.push(dayTwo);
+        expect(schedule.days.length).to.be.gte(1);
+    })
+    it("should create an availability document", function() {
+        availability = new Availability({
+            sitterId: "61e98c0cac7e7f077dae1956",
+            schedule: [schedule],
+            activeSchedule: schedule.id,
+        });
+        expect(availability).to.be.an.instanceOf(Availability);
+    });
+    it("should save an availability document", async function() {
+        const newAvailability = await availability.save();
+        expect(newAvailability).to.be.eql(availability);
+    });
+    after( function() {
+        mongoose.disconnect();
+    });
+})


### PR DESCRIPTION
### What this PR does (required):
- Availability schema for storing data related to pet sitter schedule. Set multiple days per schedule, and multiple schedules per availability. Can set active availability via the schedule Id.

### Any information needed to test this feature (required):
- Run script `npm run testAvailabilitySchema`

### Any issues with the current functionality (optional):
- n/a
